### PR TITLE
fix: add missing themes.scss import

### DIFF
--- a/src/components/button/index.tsx
+++ b/src/components/button/index.tsx
@@ -5,6 +5,7 @@ import { PressEvent } from '@react-types/shared';
 import { AriaButtonProps } from '@react-types/button';
 
 import style from './button.module.scss';
+import '../../themes/themes.scss';
 
 import { Loader } from '../loader';
 import { WithChildren, WithFlavour, WithBemClasses } from '../utils';


### PR DESCRIPTION
The import of `themes.scss` was wrongly removed from `buttons/index.tsx`.